### PR TITLE
Add Geckodriver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Update `tools/hem/config.yaml` with the following settings:
       :download:
         :mac: [Mac chromedriver url]
         :linux: [Linux chromedriver url]
+    :geckodriver:
+      :download:
+        :mac: [Mac geckodriver url]
+        :linux: [Linux geckodriver url]
+        :windows: [Windows geckodriver url]
 
 Example:
 
@@ -36,6 +41,11 @@ Example:
       :download:
         :mac: http://chromedriver.storage.googleapis.com/2.21/chromedriver_mac32.zip
         :linux: http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip
+    :geckodriver:
+      :download:
+        :mac: https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-macos.tar.gz
+        :linux: https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
+        :windows: https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-win64.zip
 
 ##### Versions
 
@@ -75,5 +85,5 @@ Examples (configs will vary):
 
 1. Run `hem selenium forward`.
     * __Selenium__ and __Chromedriver__ will be downloaded & installed automatically.
-2. Run `bin/behat -p firefox` or `bin/behat -p chrome`. 
+2. Run `bin/behat -p firefox` or `bin/behat -p chrome`.
     * Each step of a feature will now be visualised through your host `Firefox` or `Chrome` browser.

--- a/lib/hem/tasks/selenium.rb
+++ b/lib/hem/tasks/selenium.rb
@@ -1,6 +1,7 @@
 desc 'Selenium tasks'
 namespace :selenium do
   require_relative 'selenium/chromedriver'
+  require_relative 'selenium/geckodriver'
   require_relative 'selenium/install'
 
   desc 'Start Selenium'
@@ -10,6 +11,7 @@ namespace :selenium do
       "java -jar './bin/selenium-server-standalone.jar'",
         '-Dwebdriver.firefox.logfile=/tmp/selenium-firefox.log',
         '-Dwebdriver.chrome.driver=./bin/chromedriver',
+        '-Dwebdriver.gecko.driver=./bin/geckodriver',
         '-trustAllSSLCertificates',
         '> /tmp/selenium-general.log 2>&1 &',
         'echo $! > /tmp/selenium.pid'
@@ -44,6 +46,7 @@ namespace :selenium do
 
     Rake::Task['selenium:install'].invoke
     Rake::Task['selenium:chromedriver:install'].invoke
+    Rake::Task['selenium:geckodriver:install'].invoke
     Rake::Task['selenium:start'].invoke
 
     Hem.ui.success('Selenium connection forwarded into VM.')

--- a/lib/hem/tasks/selenium/geckodriver.rb
+++ b/lib/hem/tasks/selenium/geckodriver.rb
@@ -1,0 +1,29 @@
+require 'ffi'
+
+desc 'Geckodriver tasks'
+namespace :geckodriver do
+  desc 'Install Geckodriver'
+  task 'install' do
+
+    if FFI::Platform::IS_MAC
+      downloadUrl = Hem.project_config.geckodriver.download.mac
+    elsif FFI::Platform::IS_LINUX
+      downloadUrl = Hem.project_config.geckodriver.download.linux
+    elsif FFI::Platform::IS_WINDOWS
+      downloadUrl = Hem.project_config.geckodriver.download.windows
+    end
+
+    cmd = [
+      'test -f ./bin/geckodriver',
+      '|| (',
+        "wget '#{downloadUrl}' --output-document ./bin/geckodriver.zip",
+        '&& sudo yum install unzip tar -y',
+        "&& if [[ $(file --mime-type ./bin/chromedriver.zip) == *'application/zip' ]]; then unzip ./bin/chromedriver.zip -d ./bin/; else tar -xvf ./bin/chromedriver.zip -C ./bin/; fi",
+        '&& rm --force ./bin/chromedriver.zip',
+      ')'
+    ].join(' ')
+
+    run_command cmd
+    Hem.ui.success('Geckodriver Installed.')
+  end
+end


### PR DESCRIPTION
Download the paltform specific Geckodriver when needed and start
selenium server with using it.
This decouples Selenium from the Firefox version installed on the host
machine.